### PR TITLE
Fix plugin not getting data back

### DIFF
--- a/android/capacitor_qrcode/src/main/java/com/jhon/capacitor_qrcode/QRCodePlugin.java
+++ b/android/capacitor_qrcode/src/main/java/com/jhon/capacitor_qrcode/QRCodePlugin.java
@@ -10,14 +10,15 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 
 
-@NativePlugin(requestCodes = 9001)
+@NativePlugin(requestCodes = QRCodePlugin.RC_BARCODE_CAPTURE)
 public class QRCodePlugin extends Plugin {
 
-    private static final int RC_BARCODE_CAPTURE = 9001;
+    static final int RC_BARCODE_CAPTURE = 10001;
     private static final String TAG = "BarcodeMain";
 
     @PluginMethod()
     public void getCodeQR(PluginCall call) {
+        saveCall(call);
         Intent intent = new Intent(this.getBridge().getContext(), BarcodeCaptureActivity.class);
         intent.putExtra(BarcodeCaptureActivity.AutoFocus, true);
         startActivityForResult(call, intent, RC_BARCODE_CAPTURE);


### PR DESCRIPTION
You have to call `saveCall(call);` before launching an intent so it can be properly restored.
Also 9001 code is already taken by Browser plugin, so changed the code to 10001